### PR TITLE
Fix order in deploy script

### DIFF
--- a/deploy/deploy
+++ b/deploy/deploy
@@ -25,11 +25,11 @@ deploy() {
         echo "KO"
         exit 1
     }
-    ssh ${server} "cd ${remote_folder} && php tools/composer.phar update && php tools/composer.phar install" > $out 2> $err || {
+    ssh ${server} "cd ${remote_folder} && git fetch && git pull --rebase" > $out 2> $err || {
         echo "KO"
         exit 1
     }
-    ssh ${server} "cd ${remote_folder} && git fetch && git pull --rebase" > $out 2> $err || {
+    ssh ${server} "cd ${remote_folder} && php tools/composer.phar update && php tools/composer.phar install" > $out 2> $err || {
         echo "KO"
         exit 1
     }


### PR DESCRIPTION
We need to first pull the new codebase and only then install the new
dependencies.