### PR TITLE
Fix payment via Paypal

### DIFF
--- a/src/AppBundle/Controller/ProtocolController.php
+++ b/src/AppBundle/Controller/ProtocolController.php
@@ -374,7 +374,7 @@ class ProtocolController extends Controller
      * Pays a protocol.
      *
      */
-    public function payAction(Protocol $protocol, Request $request, \Swift_Mailer $mailer, PermissionsService $permissions, OrderNumberFormatter $formatter, Invoices $invoices, AlertsService $alerts)
+    public function payAction(Protocol $protocol, Request $request, Quaderno $quaderno, \Swift_Mailer $mailer, PermissionsService $permissions, OrderNumberFormatter $formatter, Invoices $invoices, AlertsService $alerts)
     {
         if (!$permissions->currentRolesInclude("customer")) {
             return $this->redirectToRoute('error', array(


### PR DESCRIPTION
A dependency injection was missing (my bad, hard to prevent because this
can only tested once deployed to production).