### PR TITLE
Replace goolge analytics code by google tag manager code

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -9,18 +9,16 @@
 <html lang="es-ES" class="no-js no-svg">
 
     <head>
-        {% if google_analytics is not null %}
-            <!-- Global site tag (gtag.js) - Google Analytics -->
-            <script async src="https://www.googletagmanager.com/gtag/js?id={{ google_analytics }}"></script>
-            <script>
-              window.dataLayer = window.dataLayer || [];
-              function gtag(){dataLayer.push(arguments);}
-              gtag('js', new Date());
-
-              gtag('config', '{{ google_analytics }}');
-            </script>
-        {% endif %}
-
+		{% if google_analytics is not null %}
+			<!-- Google Tag Manager -->
+			<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+			new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+			j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+			'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+			})(window,document,'script','dataLayer','{{ google_analytics }}');</script>
+			<!-- End Google Tag Manager -->
+		{% endif %}
+		
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
         <title>{% block title %}{{ i18n.es.metadata.page_title }}{% endblock %}</title>
@@ -52,6 +50,10 @@
     </head>
 
     <body id="top">
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5HLP9J4"
+		height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
 
         <header id="masthead" class="site-header collapsed" role="banner">
 

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -9,16 +9,14 @@
 <html lang="es-ES" class="no-js no-svg">
 
     <head>
-        {% if google_analytics is not null %}
-            <!-- Global site tag (gtag.js) - Google Analytics -->
-            <script async src="https://www.googletagmanager.com/gtag/js?id={{ google_analytics }}"></script>
-            <script>
-              window.dataLayer = window.dataLayer || [];
-              function gtag(){dataLayer.push(arguments);}
-              gtag('js', new Date());
-
-              gtag('config', '{{ google_analytics }}');
-            </script>
+		{% if google_analytics is not null %}
+			<!-- Google Tag Manager -->
+			<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+			new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+			j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+			'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+			})(window,document,'script','dataLayer','{{ google_analytics }}');</script>
+			<!-- End Google Tag Manager -->
 		{% endif %}
 		
         <meta charset="UTF-8" />
@@ -53,7 +51,11 @@
     </head>
 
     <body id="top">
-
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5HLP9J4"
+		height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
+		
         <header id="masthead" class="site-header collapsed" role="banner">
 
         <style>

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -9,16 +9,18 @@
 <html lang="es-ES" class="no-js no-svg">
 
     <head>
-		{% if google_analytics is not null %}
-			<!-- Google Tag Manager -->
-			<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-			new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-			j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-			'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-			})(window,document,'script','dataLayer','{{ google_analytics }}');</script>
-			<!-- End Google Tag Manager -->
-		{% endif %}
-		
+        {% if google_analytics is not null %}
+            <!-- Global site tag (gtag.js) - Google Analytics -->
+            <script async src="https://www.googletagmanager.com/gtag/js?id={{ google_analytics }}"></script>
+            <script>
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+
+              gtag('config', '{{ google_analytics }}');
+            </script>
+        {% endif %}
+
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
         <title>{% block title %}{{ i18n.es.metadata.page_title }}{% endblock %}</title>
@@ -50,10 +52,6 @@
     </head>
 
     <body id="top">
-		<!-- Google Tag Manager (noscript) -->
-		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5HLP9J4"
-		height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-		<!-- End Google Tag Manager (noscript) -->
 
         <header id="masthead" class="site-header collapsed" role="banner">
 

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -9,14 +9,16 @@
 <html lang="es-ES" class="no-js no-svg">
 
     <head>
-		{% if google_analytics is not null %}
-			<!-- Google Tag Manager -->
-			<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-			new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-			j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-			'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-			})(window,document,'script','dataLayer','{{ google_analytics }}');</script>
-			<!-- End Google Tag Manager -->
+        {% if google_analytics is not null %}
+            <!-- Global site tag (gtag.js) - Google Analytics -->
+            <script async src="https://www.googletagmanager.com/gtag/js?id={{ google_analytics }}"></script>
+            <script>
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+
+              gtag('config', '{{ google_analytics }}');
+            </script>
 		{% endif %}
 		
         <meta charset="UTF-8" />
@@ -28,6 +30,7 @@
                 <link rel="stylesheet" href="{{ asset_url }}" />
             {% endstylesheets %}
         {% endblock %}
+		
         <link rel="icon" type="image/x-icon" href="/web/images/favicon.ico" />
         <link rel="apple-touch-icon" sizes="57x57" href="/web/images/apple-icon-57x57.png">
         <link rel="apple-touch-icon" sizes="60x60" href="/web/images/apple-icon-60x60.png">
@@ -50,10 +53,6 @@
     </head>
 
     <body id="top">
-		<!-- Google Tag Manager (noscript) -->
-		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5HLP9J4"
-		height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-		<!-- End Google Tag Manager (noscript) -->
 
         <header id="masthead" class="site-header collapsed" role="banner">
 


### PR DESCRIPTION
We replaced the Analytics code by Google Tag Manager code.
We are using the {{ google_analytics }} var as a Google Tag Manager var, so we need to replace the Analytics ID (UA-113959294-1) by Google Tag Manager ID (GTM-5HLP9J4)